### PR TITLE
feat:add  es-lint, language change and save but have bugs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": [
+        "airbnb-base"
+    ],
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "rules": {
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "devDependencies": {
     "babel-loader": "^8.2.5",
     "css-loader": "^6.7.1",
+    "eslint": "^8.15.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.26.0",
     "html-webpack-plugin": "^5.5.0",
     "sass": "^1.51.0",
     "sass-loader": "^12.6.0",

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -67,10 +67,6 @@
 .key:hover {
     background:#79aa89
 }
-.key.active {
-    background-color:#2cfd72;
-    border-radius:50px
-}
 .MetaRight, .MetaLeft, .keyboard .AltLeft,.keyboard .AltRight,.keyboard .ArrowUp,.keyboard .ArrowLeft,.keyboard .ArrowDown,.keyboard .ArrowRight,.keyboard .Backspace,.keyboard .CapsLock,.keyboard .ControlLeft,.keyboard .ControlRight,.keyboard .Delete,.keyboard .Enter,.keyboard .ShiftLeft,.keyboard .ShiftRight,.keyboard .Tab,.keyboard .MetaLeft {
     font-weight:600;
     background-color:#222222
@@ -104,3 +100,7 @@
     width: 32px;
 }
 
+.key.active {
+    background-color:#2cfd72;
+    border-radius:50px
+}

--- a/src/scripts/addClass.js
+++ b/src/scripts/addClass.js
@@ -1,49 +1,48 @@
-
-function addClassShift(){
-    document.querySelectorAll('.caseUp').forEach(function(element){
-      element.classList.remove('hidden');
-    })
-    document.querySelectorAll('.caseDown').forEach(function(element){
-        element.classList.add('hidden');
-    })
-}
-function removeClassShift(){
-    document.querySelectorAll('.caseDown').forEach(function(element){
-        element.classList.remove('hidden');
-    })
-    document.querySelectorAll('.caseUp').forEach(function(element){
-        element.classList.add('hidden');
-    })
+function addClassShift() {
+  document.querySelectorAll('.caseUp').forEach((element) => {
+    element.classList.remove('hidden');
+  });
+  document.querySelectorAll('.caseDown').forEach((element) => {
+    element.classList.add('hidden');
+  });
 }
 
-function addCapsLock () {
-    document.querySelectorAll('.caseDown').forEach(function(element){
-        element.classList.add('hidden');
-    })
-    document.querySelectorAll('.caseUp').forEach(function(element){
-        element.classList.remove('hidden');
-    })
+function removeClassShift() {
+  document.querySelectorAll('.caseDown').forEach((element) => {
+    element.classList.remove('hidden');
+  });
+  document.querySelectorAll('.caseUp').forEach((element) => {
+    element.classList.add('hidden');
+  });
 }
 
-function removeCapsLock () {
-    document.querySelectorAll('.caseDown').forEach(function(element){
-        element.classList.remove('hidden');
-    })
-    document.querySelectorAll('.caseUp').forEach(function(element){
-        element.classList.add('hidden');
-    })
-}
-function removeCapsNumbers(){
-    const capsLockSring = 'Backquote, Digit1, Digit2, Digit3, Digit4, Digit5, Digit6, Digit7, Digit8, Digit9, Digit0, Minus, Equal';
-    document.querySelectorAll(capsLockSring).forEach(e => {
-        e.querySelectorAll('.caseDown').forEach(e => {
-            e.classList.remove('hidden');
-            console.log(e.classList)
-        })
-        // e.querySelectorAll('.caseUp').forEach(function(element){
-        //     element.classList.add('hidden');
-        // })
-    })
+function addCapsLock() {
+  document.querySelectorAll('.caseDown').forEach((element) => {
+    element.classList.add('hidden');
+  });
+  document.querySelectorAll('.caseUp').forEach((element) => {
+    element.classList.remove('hidden');
+  });
 }
 
-export {addClassShift, removeClassShift, addCapsLock, removeCapsLock, removeCapsNumbers}
+function removeCapsLock() {
+  document.querySelectorAll('.caseDown').forEach((element) => {
+    element.classList.remove('hidden');
+  });
+  document.querySelectorAll('.caseUp').forEach((element) => {
+    element.classList.add('hidden');
+  });
+}
+function removeCapsNumbers() {
+  const capsLockSring = 'Backquote, Digit1, Digit2, Digit3, Digit4, Digit5, Digit6, Digit7, Digit8, Digit9, Digit0, Minus, Equal';
+  document.querySelectorAll(capsLockSring).forEach((e) => {
+    e.querySelectorAll('.caseDown').forEach((elem) => {
+      elem.classList.remove('hidden');
+    //   console.log(e.classList)
+    });
+  });
+}
+
+export {
+  addClassShift, removeClassShift, addCapsLock, removeCapsLock, removeCapsNumbers,
+};

--- a/src/scripts/en.js
+++ b/src/scripts/en.js
@@ -1,4 +1,4 @@
-export const en = [
+const en = [
   {
     small: '`',
     shift: '~',
@@ -6,429 +6,404 @@ export const en = [
     keycode: '192',
   },
 
-    {
-      small: '1',
-      shift: '!',
-      code: 'Digit1',
-      keycode: '49',
-    },
-    {
-      small: '2',
-      shift: '@',
-      code: 'Digit2',
-      keycode: '50',
-    },
-    {
-      small: '3',
-      shift: '#',
-      code: 'Digit3',
-      keycode: '51',
-    },
-    {
-      small: '4',
-      shift: '$',
-      code: 'Digit4',
-      keycode: '52',
-    },
-    {
-      small: '5',
-      shift: '%',
-      code: 'Digit5',
-      keycode: '53',
-    },
-    {
-      small: '6',
-      shift: '^',
-      code: 'Digit6',
-      keycode: '54',
-    },
-    {
-      small: '7',
-      shift: '&',
-      code: 'Digit7',
-      keycode: '55',
-    },
-    {
-      small: '8',
-      shift: '*',
-      code: 'Digit8',
-      keycode: '56',
-    },
-    {
-      small: '9',
-      shift: '(',
-      code: 'Digit9',
-      keycode: '57',
-    },
-    {
-      small: '0',
-      shift: ')',
-      code: 'Digit0',
-      keycode: '48',
-    },
-    {
-      small: '-',
-      shift: '_',
-      code: 'Minus',
-      keycode: '189',
-    },
-    {
-      small: '=',
-      shift: '+',
-      code: 'Equal',
-      keycode: '187',
-    },
-    {
-      small: 'Backspace',
-      shift: 'Backspace',
-      code: 'Backspace',
-      keycode: '8',
-    },
+  {
+    small: '1',
+    shift: '!',
+    code: 'Digit1',
+    keycode: '49',
+  },
+  {
+    small: '2',
+    shift: '@',
+    code: 'Digit2',
+    keycode: '50',
+  },
+  {
+    small: '3',
+    shift: '#',
+    code: 'Digit3',
+    keycode: '51',
+  },
+  {
+    small: '4',
+    shift: '$',
+    code: 'Digit4',
+    keycode: '52',
+  },
+  {
+    small: '5',
+    shift: '%',
+    code: 'Digit5',
+    keycode: '53',
+  },
+  {
+    small: '6',
+    shift: '^',
+    code: 'Digit6',
+    keycode: '54',
+  },
+  {
+    small: '7',
+    shift: '&',
+    code: 'Digit7',
+    keycode: '55',
+  },
+  {
+    small: '8',
+    shift: '*',
+    code: 'Digit8',
+    keycode: '56',
+  },
+  {
+    small: '9',
+    shift: '(',
+    code: 'Digit9',
+    keycode: '57',
+  },
+  {
+    small: '0',
+    shift: ')',
+    code: 'Digit0',
+    keycode: '48',
+  },
+  {
+    small: '-',
+    shift: '_',
+    code: 'Minus',
+    keycode: '189',
+  },
+  {
+    small: '=',
+    shift: '+',
+    code: 'Equal',
+    keycode: '187',
+  },
+  {
+    small: 'Backspace',
+    shift: 'Backspace',
+    code: 'Backspace',
+    keycode: '8',
+  },
 
-    {
-      small: 'Tab',
-      shift: 'Tab',
-      code: 'Tab',
-      keycode: '9',
-    },
-    {
-      small: 'q',
-      shift: 'Q',
-      code: 'KeyQ',
-      keycode: '81',
-    },
-    {
-      small: 'w',
-      shift: 'W',
-      code: 'KeyW',
-      keycode: '87',
-    },
-    {
-      small: 'e',
-      shift: 'E',
-      code: 'KeyE',
-      keycode: '69',
-    },
-    {
-      small: 'r',
-      shift: 'R',
-      code: 'KeyR',
-      keycode: '82',
-    },
-    {
-      small: 't',
-      shift: 'T',
-      code: 'KeyT',
-      keycode: '84',
-    },
-    {
-      small: 'y',
-      shift: 'Y',
-      code: 'KeyY',
-      keycode: '89',
-    },
-    {
-      small: 'u',
-      shift: 'U',
-      code: 'KeyU',
-      keycode: '85',
-    },
-    {
-      small: 'i',
-      shift: 'I',
-      code: 'KeyI',
-      keycode: '73',
-    },
-    {
-      small: 'o',
-      shift: 'O',
-      code: 'KeyO',
-      keycode: '79',
-    },
-    {
-      small: 'p',
-      shift: 'P',
-      code: 'KeyP',
-      keycode: '80',
-    },
-    {
-      small: '[',
-      shift: '{',
-      code: 'BracketLeft',
-      keycode: '219',
-    },
-    {
-      small: ']',
-      shift: '}',
-      code: 'BracketRight',
-      keycode: '221',
-    },
+  {
+    small: 'Tab',
+    shift: 'Tab',
+    code: 'Tab',
+    keycode: '9',
+  },
+  {
+    small: 'q',
+    shift: 'Q',
+    code: 'KeyQ',
+    keycode: '81',
+  },
+  {
+    small: 'w',
+    shift: 'W',
+    code: 'KeyW',
+    keycode: '87',
+  },
+  {
+    small: 'e',
+    shift: 'E',
+    code: 'KeyE',
+    keycode: '69',
+  },
+  {
+    small: 'r',
+    shift: 'R',
+    code: 'KeyR',
+    keycode: '82',
+  },
+  {
+    small: 't',
+    shift: 'T',
+    code: 'KeyT',
+    keycode: '84',
+  },
+  {
+    small: 'y',
+    shift: 'Y',
+    code: 'KeyY',
+    keycode: '89',
+  },
+  {
+    small: 'u',
+    shift: 'U',
+    code: 'KeyU',
+    keycode: '85',
+  },
+  {
+    small: 'i',
+    shift: 'I',
+    code: 'KeyI',
+    keycode: '73',
+  },
+  {
+    small: 'o',
+    shift: 'O',
+    code: 'KeyO',
+    keycode: '79',
+  },
+  {
+    small: 'p',
+    shift: 'P',
+    code: 'KeyP',
+    keycode: '80',
+  },
+  {
+    small: '[',
+    shift: '{',
+    code: 'BracketLeft',
+    keycode: '219',
+  },
+  {
+    small: ']',
+    shift: '}',
+    code: 'BracketRight',
+    keycode: '221',
+  },
 
-    {
-        small: 'Delete',
-        shift: 'Delete',
-        code: 'Delete',
-        keycode: '46',
-      },
+  {
+    small: 'Delete',
+    shift: 'Delete',
+    code: 'Delete',
+    keycode: '46',
+  },
+  {
+    small: 'CapsLock',
+    shift: 'CapsLock',
+    code: 'CapsLock',
+    keycode: '0',
+  },
+  {
+    small: 'a',
+    shift: 'A',
+    code: 'KeyA',
+    keycode: '65',
+  },
+  {
+    small: 's',
+    shift: 'S',
+    code: 'KeyS',
+    keycode: '83',
+  },
+  {
+    small: 'd',
+    shift: 'D',
+    code: 'KeyD',
+    keycode: '68',
+  },
+  {
+    small: 'f',
+    shift: 'F',
+    code: 'KeyF',
+    keycode: '70',
+  },
+  {
+    small: 'g',
+    shift: 'G',
+    code: 'KeyG',
+    keycode: '71',
+  },
+  {
+    small: 'h',
+    shift: 'H',
+    code: 'KeyH',
+    keycode: '72',
+  },
+  {
+    small: 'j',
+    shift: 'J',
+    code: 'KeyJ',
+    keycode: '74',
+  },
+  {
+    small: 'k',
+    shift: 'K',
+    code: 'KeyK',
+    keycode: '75',
+  },
+  {
+    small: 'l',
+    shift: 'L',
+    code: 'KeyL',
+    keycode: '76',
+  },
+  {
+    small: ';',
+    shift: ':',
+    code: 'Semicolon',
+    keycode: '186',
+  },
+  {
+    small: "'",
+    shift: '"',
+    code: 'Quote',
+    keycode: '222',
+  },
+  {
+    small: '\\',
+    shift: '|',
+    code: 'Backslash',
+    keycode: '220',
+  },
+  {
+    small: 'Enter',
+    shift: 'Enter',
+    code: 'Enter',
+    keycode: 13,
+  },
 
+  {
+    small: 'Shift',
+    shift: 'Shift',
+    code: 'ShiftLeft',
+    keycode: '16',
+  },
 
+  {
+    small: '<',
+    shift: '>',
+    code: 'IntlBackslash',
+    keycode: '220',
+  },
+  {
+    small: 'z',
+    shift: 'Z',
+    code: 'KeyZ',
+    keycode: '90',
+  },
+  {
+    small: 'x',
+    shift: 'X',
+    code: 'KeyX',
+    keycode: '88',
+  },
+  {
+    small: 'c',
+    shift: 'C',
+    code: 'KeyC',
+    keycode: '67',
+  },
+  {
+    small: 'v',
+    shift: 'V',
+    code: 'KeyV',
+    keycode: '86',
+  },
+  {
+    small: 'b',
+    shift: 'B',
+    code: 'KeyB',
+    keycode: '66',
+  },
+  {
+    small: 'n',
+    shift: 'N',
+    code: 'KeyN',
+    keycode: '78',
+  },
+  {
+    small: 'm',
+    shift: 'M',
+    code: 'KeyM',
+    keycode: '77',
+  },
+  {
+    small: ',',
+    shift: '<',
+    code: 'Comma',
+    keycode: '188',
+  },
+  {
+    small: '.',
+    shift: '>',
+    code: 'Period',
+    keycode: '190',
+  },
+  {
+    small: '/',
+    shift: '?',
+    code: 'Slash',
+    keycode: '191',
+  },
+  {
+    small: '↑',
+    shift: '↑',
+    code: 'ArrowUp',
+    keycode: '40',
+  },
+  {
+    small: 'Shift',
+    shift: 'Shift',
+    code: 'ShiftRight',
+    keycode: '16',
+  },
 
+  {
+    small: 'Ctrl',
+    shift: 'Ctrl',
+    code: 'ControlLeft',
+    keycode: '17',
+  },
+  {
+    small: 'Alt',
+    shift: 'Alt',
+    code: 'AltLeft',
+    keycode: '18',
+  },
+  {
+    small: '⌘ cmd',
+    shift: '⌘ cmd',
+    code: 'MetaLeft',
+    keycode: '91',
+  },
 
+  {
+    small: ' ',
+    shift: ' ',
+    code: 'Space',
+    keycode: '32',
+  },
+  {
+    small: '⌘ cmd',
+    shift: '⌘ cmd',
+    code: 'MetaRight',
+    keycode: '91',
+  },
+  {
+    small: 'Alt',
+    shift: 'Alt',
+    code: 'AltRight',
+    keycode: '225',
+  },
 
+  {
+    small: '←',
+    shift: '←',
+    code: 'ArrowLeft',
+    keycode: '37',
+  },
+  {
+    small: '↓',
+    shift: '↓',
+    code: 'ArrowDown',
+    keycode: '38',
+  },
 
+  {
+    small: '→',
+    shift: '→',
+    code: 'ArrowRight',
+    keycode: '39',
+  },
+  {
+    small: 'fn',
+    shift: 'fn',
+    code: 'fn',
+    keycode: '1000',
+  },
+];
 
-    {
-      small: 'CapsLock',
-      shift: 'CapsLock',
-      code: 'CapsLock',
-      keycode: '0',
-    },
-    {
-      small: 'a',
-      shift: 'A',
-      code: 'KeyA',
-      keycode: '65',
-    },
-    {
-      small: 's',
-      shift: 'S',
-      code: 'KeyS',
-      keycode: '83',
-    },
-    {
-      small: 'd',
-      shift: 'D',
-      code: 'KeyD',
-      keycode: '68',
-    },
-    {
-      small: 'f',
-      shift: 'F',
-      code: 'KeyF',
-      keycode: '70',
-    },
-    {
-      small: 'g',
-      shift: 'G',
-      code: 'KeyG',
-      keycode: '71',
-    },
-    {
-      small: 'h',
-      shift: 'H',
-      code: 'KeyH',
-      keycode: '72',
-    },
-    {
-      small: 'j',
-      shift: 'J',
-      code: 'KeyJ',
-      keycode: '74',
-    },
-    {
-      small: 'k',
-      shift: 'K',
-      code: 'KeyK',
-      keycode: '75',
-    },
-    {
-      small: 'l',
-      shift: 'L',
-      code: 'KeyL',
-      keycode: '76',
-    },
-    {
-      small: ';',
-      shift: ':',
-      code: 'Semicolon',
-      keycode: '186',
-    },
-    {
-      small: "'",
-      shift: '"',
-      code: 'Quote',
-      keycode: '222',
-    },
-    {
-      small: '\\',
-      shift: '|',
-      code: 'Backslash',
-      keycode: '220',
-    },
-
-
-    {
-        small: 'Enter',
-        shift: 'Enter',
-        code: 'Enter',
-        keycode: 13,
-      },
-
-
-
-
-
-
-
-
-
-
-
-
-    {
-      small: 'Shift',
-      shift: 'Shift',
-      code: 'ShiftLeft',
-      keycode: '16',
-    },
-
-
-
-
-
-
-
-    {
-      small: '<',
-      shift: '>',
-      code: 'IntlBackslash',
-      keycode: '220',
-    },
-    {
-      small: 'z',
-      shift: 'Z',
-      code: 'KeyZ',
-      keycode: '90',
-    },
-    {
-      small: 'x',
-      shift: 'X',
-      code: 'KeyX',
-      keycode: '88',
-    },
-    {
-      small: 'c',
-      shift: 'C',
-      code: 'KeyC',
-      keycode: '67',
-    },
-    {
-      small: 'v',
-      shift: 'V',
-      code: 'KeyV',
-      keycode: '86',
-    },
-    {
-      small: 'b',
-      shift: 'B',
-      code: 'KeyB',
-      keycode: '66',
-    },
-    {
-      small: 'n',
-      shift: 'N',
-      code: 'KeyN',
-      keycode: '78',
-    },
-    {
-      small: 'm',
-      shift: 'M',
-      code: 'KeyM',
-      keycode: '77',
-    },
-    {
-      small: ',',
-      shift: '<',
-      code: 'Comma',
-      keycode: '188',
-    },
-    {
-      small: '.',
-      shift: '>',
-      code: 'Period',
-      keycode: '190',
-    },
-    {
-      small: '/',
-      shift: '?',
-      code: 'Slash',
-      keycode: '191',
-    },
-    {
-        small: '↑',
-        shift: '↑',
-        code: 'ArrowUp',
-        keycode: '40',
-      },
-    {
-      small: 'Shift',
-      shift: 'Shift',
-      code: 'ShiftRight',
-      keycode: '16',
-    },
-
-    {
-      small: 'Ctrl',
-      shift: 'Ctrl',
-      code: 'ControlLeft',
-      keycode: '17',
-    },
-    {
-      small: 'Alt',
-      shift: 'Alt',
-      code: 'AltLeft',
-      keycode: '18',
-    },
-    {
-        small: '⌘ cmd',
-        shift: '⌘ cmd',
-        code: 'MetaLeft',
-        keycode: '91',
-      },
-
-    {
-      small: ' ',
-      shift: ' ',
-      code: 'Space',
-      keycode: '32',
-    },
-    {
-        small: '⌘ cmd',
-        shift: '⌘ cmd',
-        code: 'MetaRight',
-        keycode: '91',
-      },
-    {
-      small: 'Alt',
-      shift: 'Alt',
-      code: 'AltRight',
-      keycode: '225',
-    },
-
-    {
-      small: '←',
-      shift: '←',
-      code: 'ArrowLeft',
-      keycode: '37',
-    },
-    {
-      small: '↓',
-      shift: '↓',
-      code: 'ArrowDown',
-      keycode: '38',
-    },
-
-    {
-      small: '→',
-      shift: '→',
-      code: 'ArrowRight',
-      keycode: '39',
-    },
-    {
-        small: 'fn',
-        shift: 'fn',
-        code: 'fn',
-        keycode: '1000',
-      },
-
-  ];
+export default en;

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -1,6 +1,4 @@
 // import _ from 'lodash';
-import '../assets/styles/base.scss'
-import './keyboard'
-
+import '../assets/styles/base.scss';
+import './keyboard';
 import './description';
-

--- a/src/scripts/keyClass.js
+++ b/src/scripts/keyClass.js
@@ -1,48 +1,49 @@
-export class Key {
-    constructor(objEn, objRu){
-      this.keyEn = objEn;
-      this.keyRu = objRu;
-    }
-    createKey () {
-      let key = document.createElement('div');
-      key.classList.add(this.keyEn.code, 'key')
-      let keyClassList = ['caseDown', 'caseUp', 'caps', 'shiftCaps']
-      let languageRu = document.createElement('span');
-      let languageEn = document.createElement('span');
-      if(localStorage.getItem('lang')){
-        if (localStorage.getItem('lang') === 'eng'){
-          languageEn.classList.add('eng');
-          languageRu.classList.add('rus', 'hidden');
-        } else {
-          languageEn.classList.add('eng', 'hidden');
-          languageRu.classList.add('rus');
-        }
+class Key {
+  constructor(objEn, objRu) {
+    this.keyEn = objEn;
+    this.keyRu = objRu;
+  }
+
+  createKey() {
+    const key = document.createElement('div');
+    key.classList.add(this.keyEn.code, 'key');
+    const keyClassList = ['caseDown', 'caseUp', 'caps', 'shiftCaps'];
+    const languageRu = document.createElement('span');
+    const languageEn = document.createElement('span');
+    if (localStorage.getItem('lang')) {
+      if (localStorage.getItem('lang') === 'eng') {
+        languageEn.classList.add('eng');
+        languageRu.classList.add('rus', 'hidden');
       } else {
         languageEn.classList.add('eng', 'hidden');
         languageRu.classList.add('rus');
       }
-    
-  
-      for(let i = 0; i < keyClassList.length; i++){
-        let spanRu = document.createElement('span');
-        let spanEn = document.createElement('span');
-        spanRu.classList.add(keyClassList[i]);
-        spanEn.classList.add(keyClassList[i]);
-        if (i > 0){
-          spanRu.classList.add('hidden');
-          spanEn.classList.add('hidden');
-        }
-        if(spanRu.className === 'caseDown' || spanRu.className === 'shiftCaps'){
-          spanRu.innerText = this.keyRu.small;
-          spanEn.innerText = this.keyEn.small;
-        } else {
-          spanRu.innerHTML = this.keyRu.shift;
-          spanEn.innerText = this.keyEn.shift;
-        }
-        languageRu.append(spanRu);
-        languageEn.append(spanEn);
-      }
-      key.append(languageEn,languageRu)
-      return key;
+    } else {
+      languageEn.classList.add('eng', 'hidden');
+      languageRu.classList.add('rus');
     }
+    for (let i = 0; i < keyClassList.length; i += 1) {
+      const spanRu = document.createElement('span');
+      const spanEn = document.createElement('span');
+      spanRu.classList.add(keyClassList[i]);
+      spanEn.classList.add(keyClassList[i]);
+      if (i > 0) {
+        spanRu.classList.add('hidden');
+        spanEn.classList.add('hidden');
+      }
+      if (spanRu.className === 'caseDown' || spanRu.className === 'shiftCaps') {
+        spanRu.innerText = this.keyRu.small;
+        spanEn.innerText = this.keyEn.small;
+      } else {
+        spanRu.innerHTML = this.keyRu.shift;
+        spanEn.innerText = this.keyEn.shift;
+      }
+      languageRu.append(spanRu);
+      languageEn.append(spanEn);
+    }
+    key.append(languageEn, languageRu);
+    return key;
   }
+}
+
+export default Key;

--- a/src/scripts/keyboard.js
+++ b/src/scripts/keyboard.js
@@ -1,180 +1,180 @@
 // import {ru} from './ru'
-// import {en} from './en' 
+// import {en} from './en'
 // import { forEach } from 'lodash'
 // import { Key } from './keyClass'
-import { Keyboard } from './keyboardObj'
-import {addClassShift, removeClassShift, addCapsLock, removeCapsLock} from './addClass'
+import Keyboard from './keyboardObj';
+import {
+  addClassShift, removeClassShift, addCapsLock, removeCapsLock,
+} from './addClass';
 
 Keyboard.init();
 
-let textarea = document.querySelector('#textarea');
-let pressed = new Set();
-let lang;
+const textarea = document.querySelector('#textarea');
+const pressed = new Set();
+const lang = {
+  lang: null,
+};
 
-document.addEventListener('keydown',function(e) {
+document.addEventListener('keydown', (e) => {
   e.preventDefault();
   pressed.add(e.code);
-  if (pressed.has('ControlLeft') && pressed.has('Space')){
+  if (pressed.has('ControlLeft') && pressed.has('Space')) {
     pressed.delete('ControlLeft');
     pressed.delete('Space');
-    if (Keyboard.language === 'eng'){
+    if (Keyboard.language === 'eng') {
       Keyboard.language = 'rus';
-      lang = 'rus'
-      console.log(lang)
-      document.querySelectorAll('.rus').forEach(function(element){
+      lang.lang = Keyboard.language;
+      // console.log (lang);
+      document.querySelectorAll('.rus').forEach((element) => {
         element.classList.toggle('hidden');
-      })
-      document.querySelectorAll('.eng').forEach(function(element){
+      });
+      document.querySelectorAll('.eng').forEach((element) => {
         element.classList.toggle('hidden');
-      })
+      });
     } else {
       Keyboard.language = 'eng';
-      lang ='eng';
-      console.log(lang)
-      document.querySelectorAll('.rus').forEach(function(element){
+      lang.lang = Keyboard.language;
+      // console.log(lang);
+      document.querySelectorAll('.rus').forEach((element) => {
         element.classList.toggle('hidden');
-      })
-        document.querySelectorAll('.eng').forEach(function(element){
-          element.classList.toggle('hidden');
-      })
+      });
+      document.querySelectorAll('.eng').forEach((element) => {
+        element.classList.toggle('hidden');
+      });
     }
   }
-})
+});
 
-
-document.addEventListener('keyup', function(e){
+document.addEventListener('keyup', (e) => {
   pressed.delete(e.code);
-})
-
-
-
-document.onkeydown = function(e) {
+});
+document.onkeydown = (e) => {
   e.preventDefault();
-  let keySelector = '.' + e.code;
-  let pressedKey = document.querySelector(keySelector);
-  if (e.code !== "CapsLock"){
+  const keySelector = `.${e.code}`;
+  const pressedKey = document.querySelector(keySelector);
+  if (e.code !== 'CapsLock') {
     pressedKey.classList.add('active');
   }
-  if(e.code === "Backspace"){
-    textarea.value = textarea.value.substr(0,textarea.value.length-1)
-  } 
-  else if(e.code === 'ControlLeft'|| e.code === 'MetaLeft'||e.code === 'MetaRight'||e.code === 'AltLeft'|| e.code === 'AltRight') {
-    pressed.add(e.code)
-  } else if(e.code === 'Enter'){
-    textarea.value +="\n"
-  } else if (e.code === 'ShiftLeft'|| e.code === 'ShiftRight'){
-    if(Keyboard.capsLock){
+  if (e.code === 'Backspace') {
+    textarea.value = textarea.value.substr(0, textarea.value.length - 1);
+  } else if (e.code === 'Delete') {
+    textarea.value = textarea.value.substr(1, textarea.value.length);
+  } else if (e.code === 'ControlLeft' || e.code === 'MetaLeft' || e.code === 'MetaRight' || e.code === 'AltLeft' || e.code === 'AltRight') {
+    pressed.add(e.code);
+  } else if (e.code === 'Enter') {
+    textarea.value += '\n';
+  } else if (e.code === 'ShiftLeft' || e.code === 'ShiftRight') {
+    if (Keyboard.capsLock) {
       removeClassShift();
-    } else{
+    } else {
       addClassShift();
     }
-  } else if (e.code === "CapsLock"){
+  } else if (e.code === 'CapsLock') {
     pressedKey.classList.toggle('active');
-    if(pressedKey.classList.contains('active')){
+    if (pressedKey.classList.contains('active')) {
       Keyboard.capsLock = true;
     } else {
       Keyboard.capsLock = false;
     }
-    if(Keyboard.capsLock){
+    if (Keyboard.capsLock) {
       addCapsLock();
     } else {
       removeCapsLock();
     }
-  } else if (e.code === "Tab"){
-    textarea.value +="    ";
-  }else if (e.code === "ArrowUp"||e.code === "ArrowRight"||e.code === "ArrowLeft"||e.code === "ArrowDown"){
+  } else if (e.code === 'Tab') {
+    textarea.value += '\t';
+  } else if (e.code === 'ArrowUp' || e.code === 'ArrowRight' || e.code === 'ArrowLeft' || e.code === 'ArrowDown') {
     textarea.value += pressedKey.innerText;
-  } else{
+  } else {
     textarea.value += pressedKey.innerText;
   }
-}
+};
 
-document.onkeyup = function(e){
-  let keySelector = '.' + e.code
-  document.querySelectorAll(keySelector).forEach(elem => {
-    if(e.code === 'CapsLock'){ 
-      pressed.delete(e.code)
-    } else if (e.code === 'ShiftLeft'|| e.code === 'ShiftRight'){
-      if(Keyboard.capsLock){
+document.onkeyup = (e) => {
+  const keySelector = `.${e.code}`;
+  document.querySelectorAll(keySelector).forEach((elem) => {
+    if (e.code === 'CapsLock') {
+      pressed.delete(e.code);
+    } else if (e.code === 'ShiftLeft' || e.code === 'ShiftRight') {
+      if (Keyboard.capsLock) {
         addClassShift();
       } else {
         removeClassShift();
       }
       elem.classList.remove('active');
-    }  else if(e.code === 'ControlLeft'|| e.code === 'MetaLeft'||e.code === 'MetaRight'||e.code === 'AltLeft'|| e.code === 'AltRight') {
+    } else if (e.code === 'ControlLeft' || e.code === 'MetaLeft' || e.code === 'MetaRight' || e.code === 'AltLeft' || e.code === 'AltRight') {
       pressed.delete(e.code);
       elem.classList.remove('active');
     } else {
       elem.classList.remove('active');
     }
-  })
-}
+  });
+};
 
-
-document.querySelectorAll('.key').forEach(function(element){
-  element.addEventListener('mousedown', (e)=>{
-  let pressedKey = e.currentTarget;
-
-  if (pressedKey.classList.contains("CapsLock")){
-    pressedKey.classList.toggle('active');
-  } else {
-    pressedKey.classList.add('active');
-  }
-  if (pressedKey.innerText === 'Backspace'){
-    textarea.value = textarea.value.substr(0,textarea.value.length-1)
-  } else if (pressedKey.innerText === 'Ctrl' || pressedKey.innerText === '⌘ cmd'|| pressedKey.innerText === 'Alt') {
-    pressed.add(e.code);
-  } else if (pressedKey.innerText === 'Shift'){
-    if(Keyboard.capsLock){
-      removeClassShift();
-    } else{
-      addClassShift();
-    }
-  }else if (pressedKey.innerText === 'CapsLock') {
-    if(pressedKey.classList.contains('active')){
-      Keyboard.capsLock = true;
+document.querySelectorAll('.key').forEach((element) => {
+  element.addEventListener('mousedown', (e) => {
+    const pressedKey = e.currentTarget;
+    if (pressedKey.classList.contains('CapsLock')) {
+      pressedKey.classList.toggle('active');
     } else {
-      Keyboard.capsLock = false;
+      pressedKey.classList.add('active');
     }
-    if(Keyboard.capsLock){
-      addCapsLock();
+    if (pressedKey.innerText === 'Backspace') {
+      textarea.value = textarea.value.substr(0, textarea.value.length - 1);
+    } else if (pressedKey.innerText === 'Ctrl' || pressedKey.innerText === '⌘ cmd' || pressedKey.innerText === 'Alt') {
+      pressed.add(e.code);
+    } else if (pressedKey.innerText === 'Shift') {
+      if (Keyboard.capsLock) {
+        removeClassShift();
+      } else {
+        addClassShift();
+      }
+    } else if (pressedKey.innerText === 'Delete') {
+      textarea.value = textarea.value.substr(1, textarea.value.length);
+    } else if (pressedKey.innerText === 'CapsLock') {
+      if (pressedKey.classList.contains('active')) {
+        Keyboard.capsLock = true;
+      } else {
+        Keyboard.capsLock = false;
+      }
+      if (Keyboard.capsLock) {
+        addCapsLock();
+      } else {
+        removeCapsLock();
+      }
+    } else if (pressedKey.innerText === 'Enter') {
+      textarea.value += '\n';
+    } else if (pressedKey.innerText === 'Tab') {
+      textarea.value += '\t';
+    } else if (pressedKey.innerText === '') {
+      textarea.value += ' ';
     } else {
-      removeCapsLock();
+      textarea.value += e.currentTarget.innerText;
     }
-  }else if(pressedKey.innerText === 'Enter'){
-    textarea.value +="\n"
-  }else if(pressedKey.innerText === 'Tab'){
-    textarea.value += '    ';
-  }else if(pressedKey.innerText === ''){
-    textarea.value += ' ';
-  }
-  else{
-    textarea.value += e.currentTarget.innerText;
-  }
-})
-})
+  });
+});
 
-document.querySelectorAll('.key').forEach(function(element){
-  element.addEventListener('mouseup', (e)=>{
-  let pressedKey = e.currentTarget;
-  if(pressedKey.innerText === 'Shift'){
-    pressedKey.classList.remove('active');
-    if(Keyboard.capsLock){
-      addClassShift();
-    } else {
-      removeClassShift();
+document.querySelectorAll('.key').forEach((element) => {
+  element.addEventListener('mouseup', (e) => {
+    const pressedKey = e.currentTarget;
+    if (pressedKey.innerText === 'Shift') {
+      pressedKey.classList.remove('active');
+      if (Keyboard.capsLock) {
+        addClassShift();
+      } else {
+        removeClassShift();
+      }
+    } else if (pressedKey.innerText !== 'CapsLock') {
+      pressedKey.classList.remove('active');
+    } else if (pressedKey.innerText === 'Ctrl' || pressedKey.innerText === '⌘ cmd' || pressedKey.innerText === 'Alt') {
+      pressed.delete(e.code);
     }
-  } else if(pressedKey.innerText !== 'CapsLock'){
-    pressedKey.classList.remove('active');
-  } else if (pressedKey.innerText === 'Ctrl' || pressedKey.innerText === '⌘ cmd'|| pressedKey.innerText === 'Alt') {
-    pressed.delete(e.code);
-  }
-})
-})
+  });
+});
 
-window.onunload = function(){
+window.onunload = () => {
   localStorage.clear();
-  console.log(lang)
-  localStorage.setItem('lang', lang);
-  console.log(localStorage)
-}
+  // console.log(lang);
+  localStorage.setItem('lang', lang.lang);
+  // console.log(localStorage);
+};

--- a/src/scripts/keyboardObj.js
+++ b/src/scripts/keyboardObj.js
@@ -1,98 +1,94 @@
-import {ru} from './ru'
-import {en} from './en' 
-import { Key } from './keyClass'
+import ru from './ru';
+import en from './en';
+import Key from './keyClass';
 
-export const Keyboard = {
-    elements:{
-      main:null,
-      title:null,
-      textarea:null,
-      keyboardContainer:null,
-      keyboardRow:{
-        row1:null,
-        row2:null,
-        row3:null,
-        row4:null,
-        row5:null,
-      },
-      language:'rus',
-      capsLock:false,
-      shift:false,
+const Keyboard = {
+  elements: {
+    main: null,
+    title: null,
+    textarea: null,
+    keyboardContainer: null,
+    keyboardRow: {
+      row1: null,
+      row2: null,
+      row3: null,
+      row4: null,
+      row5: null,
     },
-  
-    init (){
-  
-      this.elements.main = document.createElement('div');
-      this.elements.title = document.createElement('p');
-      this.elements.textarea = document.createElement('textarea');
-      this.elements.keyboardContainer = document.createElement('div')
-      this.elements.description = document.createElement('p');
-      this.elements.language = document.createElement('p');
-      this.elements.keyboardRow.row1 = document.createElement('div');
-      this.elements.keyboardRow.row2 = document.createElement('div');
-      this.elements.keyboardRow.row3 = document.createElement('div');
-      this.elements.keyboardRow.row4 = document.createElement('div');
-      this.elements.keyboardRow.row5 = document.createElement('div');
-  
-  
-      this.elements.main.classList.add('centralizer');
-      this.elements.title.classList.add('title');
-      this.elements.textarea.classList.add('textarea');
-      this.elements.keyboardContainer.classList.add('keyboard', 'body-keyboard');
-      this.elements.description.classList.add('description');
-      this.elements.language.classList.add('language');
-      this.elements.keyboardRow.row1.classList.add('row', 'keyboard-row');
-      this.elements.keyboardRow.row2.classList.add('row', 'keyboard-row');
-      this.elements.keyboardRow.row3.classList.add('row', 'keyboard-row');
-      this.elements.keyboardRow.row4.classList.add('row', 'keyboard-row');
-      this.elements.keyboardRow.row5.classList.add('row', 'keyboard-row');
-  
-      this.elements.title.innerText = 'RSS Виртуальная клавиатура';
-      this.elements.description.innerText = 'Клавиатура создана в операционной системе Apple';
-      this.elements.language.innerText = 'Для переключения языка комбинация: spase + левый ctrl';
-      
-      this.elements.textarea.id = 'textarea';
-      this.elements.textarea.rows = '5';
-      this.elements.textarea.cols = '50';
-      for(let i = 0; i < 14; i++){
-        let enNul = en[i];
-        let ruNul = ru[i]
-        const keyCreater = new Key(enNul, ruNul);
-        let key = keyCreater.createKey();
-        this.elements.keyboardRow.row1.append(key);
-      }
-      for(let i = 14; i < 28; i++){
-        let enNul = en[i];
-        let ruNul = ru[i]
-        const keyCreater = new Key(enNul, ruNul);
-        let key = keyCreater.createKey();
-        this.elements.keyboardRow.row2.append(key);
-      }
-      for(let i = 28; i < 42; i++){
-        let enNul = en[i];
-        let ruNul = ru[i]
-        const keyCreater = new Key(enNul, ruNul);
-        let key = keyCreater.createKey();
-        this.elements.keyboardRow.row3.append(key);
-      }
-      for(let i = 42; i < 56; i++){
-        let enNul = en[i];
-        let ruNul = ru[i]
-        const keyCreater = new Key(enNul, ruNul);
-        let key = keyCreater.createKey();
-        this.elements.keyboardRow.row4.append(key);
-      }
-      for(let i = 56; i < 66; i++){
-        let enNul = en[i];
-        let ruNul = ru[i]
-        const keyCreater = new Key(enNul, ruNul);
-        let key = keyCreater.createKey();
-        this.elements.keyboardRow.row5.append(key);
-      }
-      this.elements.keyboardContainer.append(this.elements.keyboardRow.row1, this.elements.keyboardRow.row2, this.elements.keyboardRow.row3, this.elements.keyboardRow.row4, this.elements.keyboardRow.row5);
-      this.elements.main.append(this.elements.title, this.elements.textarea, this.elements.keyboardContainer, this.elements.description, this.elements.language);
-      document.body.append(this.elements.main);
-      
+    language: 'rus',
+    capsLock: false,
+    shift: false,
+  },
+  init() {
+    this.elements.main = document.createElement('div');
+    this.elements.title = document.createElement('p');
+    this.elements.textarea = document.createElement('textarea');
+    this.elements.keyboardContainer = document.createElement('div');
+    this.elements.description = document.createElement('p');
+    this.elements.language = document.createElement('p');
+    this.elements.keyboardRow.row1 = document.createElement('div');
+    this.elements.keyboardRow.row2 = document.createElement('div');
+    this.elements.keyboardRow.row3 = document.createElement('div');
+    this.elements.keyboardRow.row4 = document.createElement('div');
+    this.elements.keyboardRow.row5 = document.createElement('div');
+    this.elements.main.classList.add('centralizer');
+    this.elements.title.classList.add('title');
+    this.elements.textarea.classList.add('textarea');
+    this.elements.keyboardContainer.classList.add('keyboard', 'body-keyboard');
+    this.elements.description.classList.add('description');
+    this.elements.language.classList.add('language');
+    this.elements.keyboardRow.row1.classList.add('row', 'keyboard-row');
+    this.elements.keyboardRow.row2.classList.add('row', 'keyboard-row');
+    this.elements.keyboardRow.row3.classList.add('row', 'keyboard-row');
+    this.elements.keyboardRow.row4.classList.add('row', 'keyboard-row');
+    this.elements.keyboardRow.row5.classList.add('row', 'keyboard-row');
+    this.elements.title.innerText = 'RSS Виртуальная клавиатура';
+    this.elements.description.innerText = 'Клавиатура создана в операционной системе Apple';
+    this.elements.language.innerText = 'Для переключения языка комбинация: spase + левый ctrl';
+    this.elements.textarea.id = 'textarea';
+    this.elements.textarea.rows = '5';
+    this.elements.textarea.cols = '50';
+    for (let i = 0; i < 14; i += 1) {
+      const enNul = en[i];
+      const ruNul = ru[i];
+      const keyCreater = new Key(enNul, ruNul);
+      const key = keyCreater.createKey();
+      this.elements.keyboardRow.row1.append(key);
     }
-  
-  }
+    for (let i = 14; i < 28; i += 1) {
+      const enNul = en[i];
+      const ruNul = ru[i];
+      const keyCreater = new Key(enNul, ruNul);
+      const key = keyCreater.createKey();
+      this.elements.keyboardRow.row2.append(key);
+    }
+    for (let i = 28; i < 42; i += 1) {
+      const enNul = en[i];
+      const ruNul = ru[i];
+      const keyCreater = new Key(enNul, ruNul);
+      const key = keyCreater.createKey();
+      this.elements.keyboardRow.row3.append(key);
+    }
+    for (let i = 42; i < 56; i += 1) {
+      const enNul = en[i];
+      const ruNul = ru[i];
+      const keyCreater = new Key(enNul, ruNul);
+      const key = keyCreater.createKey();
+      this.elements.keyboardRow.row4.append(key);
+    }
+    for (let i = 56; i < 66; i += 1) {
+      const enNul = en[i];
+      const ruNul = ru[i];
+      const keyCreater = new Key(enNul, ruNul);
+      const key = keyCreater.createKey();
+      this.elements.keyboardRow.row5.append(key);
+    }
+    // eslint-disable-next-line max-len
+    this.elements.keyboardContainer.append(this.elements.keyboardRow.row1, this.elements.keyboardRow.row2, this.elements.keyboardRow.row3, this.elements.keyboardRow.row4, this.elements.keyboardRow.row5);
+    // eslint-disable-next-line max-len
+    this.elements.main.append(this.elements.title, this.elements.textarea, this.elements.keyboardContainer, this.elements.description, this.elements.language);
+    document.body.append(this.elements.main);
+  },
+};
+
+export default Keyboard;

--- a/src/scripts/ru.js
+++ b/src/scripts/ru.js
@@ -1,424 +1,407 @@
-export const ru = [
-    {
-        small: '>',
-        shift: '<',
-        code: 'Backslash',
-        keycode: '220',
-      },
-    {
-      small: '1',
-      shift: '!',
-      code: 'Digit1',
-      keycode: '49',
-    },
-    {
-      small: '2',
-      shift: '"',
-      code: 'Digit2',
-      keycode: '50',
-    },
-    {
-      small: '3',
-      shift: '№',
-      code: 'Digit3',
-      keycode: '51',
-    },
-    {
-      small: '4',
-      shift: ';',
-      code: 'Digit4',
-      keycode: '52',
-    },
-    {
-      small: '5',
-      shift: '%',
-      code: 'Digit5',
-      keycode: '53',
-    },
-    {
-      small: '6',
-      shift: ':',
-      code: 'Digit6',
-      keycode: '54',
-    },
-    {
-      small: '7',
-      shift: '?',
-      code: 'Digit7',
-      keycode: '55',
-    },
-    {
-      small: '8',
-      shift: '*',
-      code: 'Digit8',
-      keycode: '56',
-    },
-    {
-      small: '9',
-      shift: '(',
-      code: 'Digit9',
-      keycode: '57',
-    },
-    {
-      small: '0',
-      shift: ')',
-      code: 'Digit0',
-      keycode: '48',
-    },
-    {
-      small: '-',
-      shift: '_',
-      code: 'Minus',
-      keycode: '189',
-    },
-    {
-      small: '=',
-      shift: '+',
-      code: 'Equal',
-      keycode: '187',
-    },
-    {
-      small: 'Backspace',
-      shift: 'Backspace',
-      code: 'Backspace',
-      keycode: '8',
-    },
- 
+const ru = [
+  {
+    small: '>',
+    shift: '<',
+    code: 'Backslash',
+    keycode: '220',
+  },
+  {
+    small: '1',
+    shift: '!',
+    code: 'Digit1',
+    keycode: '49',
+  },
+  {
+    small: '2',
+    shift: '"',
+    code: 'Digit2',
+    keycode: '50',
+  },
+  {
+    small: '3',
+    shift: '№',
+    code: 'Digit3',
+    keycode: '51',
+  },
+  {
+    small: '4',
+    shift: ';',
+    code: 'Digit4',
+    keycode: '52',
+  },
+  {
+    small: '5',
+    shift: '%',
+    code: 'Digit5',
+    keycode: '53',
+  },
+  {
+    small: '6',
+    shift: ':',
+    code: 'Digit6',
+    keycode: '54',
+  },
+  {
+    small: '7',
+    shift: '?',
+    code: 'Digit7',
+    keycode: '55',
+  },
+  {
+    small: '8',
+    shift: '*',
+    code: 'Digit8',
+    keycode: '56',
+  },
+  {
+    small: '9',
+    shift: '(',
+    code: 'Digit9',
+    keycode: '57',
+  },
+  {
+    small: '0',
+    shift: ')',
+    code: 'Digit0',
+    keycode: '48',
+  },
+  {
+    small: '-',
+    shift: '_',
+    code: 'Minus',
+    keycode: '189',
+  },
+  {
+    small: '=',
+    shift: '+',
+    code: 'Equal',
+    keycode: '187',
+  },
+  {
+    small: 'Backspace',
+    shift: 'Backspace',
+    code: 'Backspace',
+    keycode: '8',
+  },
+  {
+    small: 'Tab',
+    shift: 'Tab',
+    code: 'Tab',
+    keycode: '9',
+  },
+  {
+    small: 'й',
+    shift: 'Й',
+    code: 'KeyQ',
+    keycode: '81',
+  },
+  {
+    small: 'ц',
+    shift: 'Ц',
+    code: 'KeyW',
+    keycode: '87',
+  },
+  {
+    small: 'у',
+    shift: 'У',
+    code: 'KeyE',
+    keycode: '69',
+  },
+  {
+    small: 'к',
+    shift: 'К',
+    code: 'KeyR',
+    keycode: '82',
+  },
+  {
+    small: 'е',
+    shift: 'Е',
+    code: 'KeyT',
+    keycode: '84',
+  },
+  {
+    small: 'н',
+    shift: 'Н',
+    code: 'KeyY',
+    keycode: '89',
+  },
+  {
+    small: 'г',
+    shift: 'Г',
+    code: 'KeyU',
+    keycode: '85',
+  },
+  {
+    small: 'ш',
+    shift: 'Ш',
+    code: 'KeyI',
+    keycode: '73',
+  },
+  {
+    small: 'щ',
+    shift: 'Щ',
+    code: 'KeyO',
+    keycode: '79',
+  },
+  {
+    small: 'з',
+    shift: 'З',
+    code: 'KeyP',
+    keycode: '80',
+  },
+  {
+    small: 'х',
+    shift: 'Х',
+    code: 'BracketLeft',
+    keycode: '219',
+  },
+  {
+    small: 'ъ',
+    shift: 'Ъ',
+    code: 'BracketRight',
+    keycode: '221',
+  },
+  {
+    small: 'Delete',
+    shift: 'Delete',
+    code: 'Delete',
+    keycode: '46',
+  },
 
+  {
+    small: 'CapsLock',
+    shift: 'CapsLock',
+    code: 'CapsLock',
+    keycode: '0',
+  },
+  {
+    small: 'ф',
+    shift: 'Ф',
+    code: 'KeyA',
+    keycode: '65',
+  },
+  {
+    small: 'ы',
+    shift: 'Ы',
+    code: 'KeyS',
+    keycode: '83',
+  },
+  {
+    small: 'в',
+    shift: 'В',
+    code: 'KeyD',
+    keycode: '68',
+  },
+  {
+    small: 'а',
+    shift: 'А',
+    code: 'KeyF',
+    keycode: '70',
+  },
+  {
+    small: 'п',
+    shift: 'П',
+    code: 'KeyG',
+    keycode: '71',
+  },
+  {
+    small: 'р',
+    shift: 'Р',
+    code: 'KeyH',
+    keycode: '72',
+  },
+  {
+    small: 'о',
+    shift: 'О',
+    code: 'KeyJ',
+    keycode: '74',
+  },
+  {
+    small: 'л',
+    shift: 'Л',
+    code: 'KeyK',
+    keycode: '75',
+  },
+  {
+    small: 'д',
+    shift: 'Д',
+    code: 'KeyL',
+    keycode: '76',
+  },
+  {
+    small: 'ж',
+    shift: 'Ж',
+    code: 'Semicolon',
+    keycode: '186',
+  },
+  {
+    small: 'э',
+    shift: 'Э',
+    code: 'Quote',
+    keycode: '222',
+  },
 
+  {
+    small: 'ё',
+    shift: 'Ё',
+    code: 'Backquote',
+    keycode: '192',
+  },
+  {
+    small: 'Enter',
+    shift: 'Enter',
+    code: 'Enter',
+    keycode: '13',
+  },
+  {
+    small: 'Shift',
+    shift: 'Shift',
+    code: 'ShiftLeft',
+    keycode: '16',
+  },
+  {
+    small: ']',
+    shift: '[',
+    code: 'IntlBackslash',
+    keycode: '191',
+  },
+  {
+    small: 'я',
+    shift: 'Я',
+    code: 'KeyZ',
+    keycode: '90',
+  },
+  {
+    small: 'ч',
+    shift: 'Ч',
+    code: 'KeyX',
+    keycode: '88',
+  },
+  {
+    small: 'с',
+    shift: 'С',
+    code: 'KeyC',
+    keycode: '67',
+  },
+  {
+    small: 'м',
+    shift: 'М',
+    code: 'KeyV',
+    keycode: '86',
+  },
+  {
+    small: 'и',
+    shift: 'И',
+    code: 'KeyB',
+    keycode: '66',
+  },
+  {
+    small: 'т',
+    shift: 'Т',
+    code: 'KeyN',
+    keycode: '78',
+  },
+  {
+    small: 'ь',
+    shift: 'Ь',
+    code: 'KeyM',
+    keycode: '77',
+  },
+  {
+    small: 'б',
+    shift: 'Б',
+    code: 'Comma',
+    keycode: '188',
+  },
+  {
+    small: 'ю',
+    shift: 'Ю',
+    code: 'Period',
+    keycode: '190',
+  },
+  {
+    small: '.',
+    shift: ',',
+    code: 'Slash',
+    keycode: '191',
+  },
+  {
+    small: '↑',
+    shift: '↑',
+    code: 'ArrowUp',
+    keycode: '38',
+  },
 
+  {
+    small: 'Shift',
+    shift: 'Shift',
+    code: 'ShiftRight',
+    keycode: '16',
+  },
 
+  {
+    small: 'Ctrl',
+    shift: 'Ctrl',
+    code: 'ControlLeft',
+    keycode: '17',
+  },
+  {
+    small: 'Alt',
+    shift: 'Alt',
+    code: 'AltLeft',
+    keycode: '18',
+  },
+  {
+    small: '⌘ cmd',
+    shift: '⌘ cmd',
+    code: 'MetaLeft',
+    keycode: '91',
+  },
+  {
+    small: ' ',
+    shift: ' ',
+    code: 'Space',
+    keycode: '32',
+  },
+  {
+    small: '⌘ cmd',
+    shift: '⌘ cmd',
+    code: 'MetaRight',
+    keycode: '91',
+  },
+  {
+    small: 'Alt',
+    shift: 'Alt',
+    code: 'AltRight',
+    keycode: '225',
+  },
 
-    {
-      small: 'Tab',
-      shift: 'Tab',
-      code: 'Tab',
-      keycode: '9',
-    },
-    {
-      small: 'й',
-      shift: 'Й',
-      code: 'KeyQ',
-      keycode: '81',
-    },
-    {
-      small: 'ц',
-      shift: 'Ц',
-      code: 'KeyW',
-      keycode: '87',
-    },
-    {
-      small: 'у',
-      shift: 'У',
-      code: 'KeyE',
-      keycode: '69',
-    },
-    {
-      small: 'к',
-      shift: 'К',
-      code: 'KeyR',
-      keycode: '82',
-    },
-    {
-      small: 'е',
-      shift: 'Е',
-      code: 'KeyT',
-      keycode: '84',
-    },
-    {
-      small: 'н',
-      shift: 'Н',
-      code: 'KeyY',
-      keycode: '89',
-    },
-    {
-      small: 'г',
-      shift: 'Г',
-      code: 'KeyU',
-      keycode: '85',
-    },
-    {
-      small: 'ш',
-      shift: 'Ш',
-      code: 'KeyI',
-      keycode: '73',
-    },
-    {
-      small: 'щ',
-      shift: 'Щ',
-      code: 'KeyO',
-      keycode: '79',
-    },
-    {
-      small: 'з',
-      shift: 'З',
-      code: 'KeyP',
-      keycode: '80',
-    },
-    {
-      small: 'х',
-      shift: 'Х',
-      code: 'BracketLeft',
-      keycode: '219',
-    },
-    {
-      small: 'ъ',
-      shift: 'Ъ',
-      code: 'BracketRight',
-      keycode: '221',
-    },
-    {
-        small: 'Delete',
-        shift: 'Delete',
-        code: 'Delete',
-        keycode: '46',
-      },
+  {
+    small: '←',
+    shift: '←',
+    code: 'ArrowLeft',
+    keycode: '37',
+  },
 
+  {
+    small: '↓',
+    shift: '↓',
+    code: 'ArrowDown',
+    keycode: '40',
+  },
+  {
+    small: '→',
+    shift: '→',
+    code: 'ArrowRight',
+    keycode: '39',
+  },
 
+  {
+    small: 'fn',
+    shift: 'fn',
+    code: 'fn',
+    keycode: '1000',
+  },
+];
 
-
-
-
-    {
-        small: 'CapsLock',
-        shift: 'CapsLock',
-        code: 'CapsLock',
-        keycode: '0',
-      },
-    {
-      small: 'ф',
-      shift: 'Ф',
-      code: 'KeyA',
-      keycode: '65',
-    },
-    {
-      small: 'ы',
-      shift: 'Ы',
-      code: 'KeyS',
-      keycode: '83',
-    },
-    {
-      small: 'в',
-      shift: 'В',
-      code: 'KeyD',
-      keycode: '68',
-    },
-    {
-      small: 'а',
-      shift: 'А',
-      code: 'KeyF',
-      keycode: '70',
-    },
-    {
-      small: 'п',
-      shift: 'П',
-      code: 'KeyG',
-      keycode: '71',
-    },
-    {
-      small: 'р',
-      shift: 'Р',
-      code: 'KeyH',
-      keycode: '72',
-    },
-    {
-      small: 'о',
-      shift: 'О',
-      code: 'KeyJ',
-      keycode: '74',
-    },
-    {
-      small: 'л',
-      shift: 'Л',
-      code: 'KeyK',
-      keycode: '75',
-    },
-    {
-      small: 'д',
-      shift: 'Д',
-      code: 'KeyL',
-      keycode: '76',
-    },
-    {
-      small: 'ж',
-      shift: 'Ж',
-      code: 'Semicolon',
-      keycode: '186',
-    },
-    {
-      small: 'э',
-      shift: 'Э',
-      code: 'Quote',
-      keycode: '222',
-    },
-    {
-        small: 'ё',
-        shift: 'Ё',
-        code: 'Backquote',
-        keycode: '192',
-      },
-    {
-        small: 'Enter',
-        shift: 'Enter',
-        code: 'Enter',
-        keycode: '13',
-      },
-
-
-
-
-
-    {
-      small: 'Shift',
-      shift: 'Shift',
-      code: 'ShiftLeft',
-      keycode: '16',
-    },
-    {
-      small: ']',
-      shift: '[',
-      code: 'IntlBackslash',
-      keycode: '191',
-    },
-    {
-      small: 'я',
-      shift: 'Я',
-      code: 'KeyZ',
-      keycode: '90',
-    },
-    {
-      small: 'ч',
-      shift: 'Ч',
-      code: 'KeyX',
-      keycode: '88',
-    },
-    {
-      small: 'с',
-      shift: 'С',
-      code: 'KeyC',
-      keycode: '67',
-    },
-    {
-      small: 'м',
-      shift: 'М',
-      code: 'KeyV',
-      keycode: '86',
-    },
-    {
-      small: 'и',
-      shift: 'И',
-      code: 'KeyB',
-      keycode: '66',
-    },
-    {
-      small: 'т',
-      shift: 'Т',
-      code: 'KeyN',
-      keycode: '78',
-    },
-    {
-      small: 'ь',
-      shift: 'Ь',
-      code: 'KeyM',
-      keycode: '77',
-    },
-    {
-      small: 'б',
-      shift: 'Б',
-      code: 'Comma',
-      keycode: '188',
-    },
-    {
-      small: 'ю',
-      shift: 'Ю',
-      code: 'Period',
-      keycode: '190',
-    },
-    {
-      small: '.',
-      shift: ',',
-      code: 'Slash',
-      keycode: '191',
-    },
-    {
-        small: '↑',
-        shift: '↑',
-        code: 'ArrowUp',
-        keycode: '38',
-      },
-
-    {
-      small: 'Shift',
-      shift: 'Shift',
-      code: 'ShiftRight',
-      keycode: '16',
-    },
-
-
-
-
-
-    {
-      small: 'Ctrl',
-      shift: 'Ctrl',
-      code: 'ControlLeft',
-      keycode: '17',
-    },
-    {
-      small: 'Alt',
-      shift: 'Alt',
-      code: 'AltLeft',
-      keycode: '18',
-    },
-    {
-        small: '⌘ cmd',
-        shift: '⌘ cmd',
-        code: 'MetaLeft',
-        keycode: '91',
-      },
-    {
-      small: ' ',
-      shift: ' ',
-      code: 'Space',
-      keycode: '32',
-    },
-    {
-        small: '⌘ cmd',
-        shift: '⌘ cmd',
-        code: 'MetaRight',
-        keycode: '91',
-      },
-    {
-      small: 'Alt',
-      shift: 'Alt',
-      code: 'AltRight',
-      keycode: '225',
-    },
-
-    {
-      small: '←',
-      shift: '←',
-      code: 'ArrowLeft',
-      keycode: '37',
-    },
-
-    {
-      small: '↓',
-      shift: '↓',
-      code: 'ArrowDown',
-      keycode: '40',
-    },
-    {
-      small: '→',
-      shift: '→',
-      code: 'ArrowRight',
-      keycode: '39',
-    },
-
-    {
-        small: 'fn',
-        shift: 'fn',
-        code: 'fn',
-        keycode: '1000',
-      },
-  ];
+export default ru;


### PR DESCRIPTION
1.https://github.com/rolling-scopes-school/tasks/blob/master/tasks/virtual-keyboard/virtual-keyboard-en.md
2.
image
3.https://alexkochnev1987.github.io/virtual-keyboard/dist/index.html
4.done 9.05.2022/deadline 10.05.2022
5. 60-80/110

+the generation of DOM elements is implemented. body in the index.html is empty (can contain only script tag): +20
+pressing a key on a physical keyboard highlights the key on the virtual keyboard (you should check keystrokes of numbers, letters, punctuation marks, backspace, del (if it's present), enter, shift, alt, ctrl, tab, caps lock, space, arrow keys: +10
+-switching keyboard layouts between English and another language is implemented. Selected language should be saved and used on page reload. A keyboard shortcut for switching a language should be specified on the page: +15(Я не понимаю почему в localstorage сохраняется не то что нужно и не всегда а через раз, или меняется язык, если скинешь ссылку что прочитать чтобы это сделать от меня большой респект)
+mouse clicks on buttons of the virtual keyboard or pressing buttons on a physical keyboard inputs characters to the input field (text area): +15
+animation of pressing a key is implemented: +15
+usage of ES6+ features (classes, property destructuring, etc): +15
+usage of ESLint: +10
+?requirements to the repository, commits and pull request are met: +10