### PR TITLE
fix: language save and load properly

### DIFF
--- a/src/scripts/keyboard.js
+++ b/src/scripts/keyboard.js
@@ -26,20 +26,20 @@ document.addEventListener('keydown', (e) => {
       lang.lang = Keyboard.language;
       // console.log (lang);
       document.querySelectorAll('.rus').forEach((element) => {
-        element.classList.toggle('hidden');
+        element.classList.remove('hidden');
       });
       document.querySelectorAll('.eng').forEach((element) => {
-        element.classList.toggle('hidden');
+        element.classList.add('hidden');
       });
     } else {
       Keyboard.language = 'eng';
       lang.lang = Keyboard.language;
       // console.log(lang);
       document.querySelectorAll('.rus').forEach((element) => {
-        element.classList.toggle('hidden');
+        element.classList.add('hidden');
       });
       document.querySelectorAll('.eng').forEach((element) => {
-        element.classList.toggle('hidden');
+        element.classList.remove('hidden');
       });
     }
   }


### PR DESCRIPTION
1.https://github.com/rolling-scopes-school/tasks/blob/master/tasks/virtual-keyboard/virtual-keyboard-en.md
2.
![image](https://user-images.githubusercontent.com/92919510/167677601-3d9e19f3-a3c7-4f2b-bf7f-baff57dd5720.png)

3.https://alexkochnev1987.github.io/virtual-keyboard/dist/index.html
4.done 9.05.2022/deadline 10.05.2022
5. 60-80/110

+the generation of DOM elements is implemented. body in the index.html is empty (can contain only script tag): +20
+pressing a key on a physical keyboard highlights the key on the virtual keyboard (you should check keystrokes of numbers, letters, punctuation marks, backspace, del (if it's present), enter, shift, alt, ctrl, tab, caps lock, space, arrow keys: +10
+switching keyboard layouts between English and another language is implemented. Selected language should be saved and used on page reload. A keyboard shortcut for switching a language should be specified on the page: +15
+mouse clicks on buttons of the virtual keyboard or pressing buttons on a physical keyboard inputs characters to the input field (text area): +15
+animation of pressing a key is implemented: +15
+usage of ES6+ features (classes, property destructuring, etc): +15
+usage of ESLint: +10
+?requirements to the repository, commits and pull request are met: +10